### PR TITLE
Add user agent to request

### DIFF
--- a/src/Deadlinks/UrlScanner.php
+++ b/src/Deadlinks/UrlScanner.php
@@ -74,6 +74,9 @@ class UrlScanner
         curl_setopt($ch, CONNECTION_TIMEOUT, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'User-Agent: Dead Links URL scanner',
+        ]);
 
         return $ch;
     }


### PR DESCRIPTION
 Some requests got a 500 Internal Error message. This occured because some servers require a user agent to be set in the request.

Added a user agent to the curl request.